### PR TITLE
fix(security): pin js-yaml 4.1.1 (lerna exact dep) to 4.2.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "tar@npm:7.5.11": "npm:^7.5.16",
     "brace-expansion@npm:^1.1.7": "npm:^1.1.13",
     "js-yaml@npm:^3.13.1": "npm:^3.15.0",
+    "js-yaml@npm:4.1.1": "npm:^4.2.0",
     "ip-address@npm:^9.0.5": "npm:^10.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7193,17 +7193,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
-  languageName: node
-  linkType: hard
-
 "js-yaml@npm:^3.15.0":
   version: 3.15.0
   resolution: "js-yaml@npm:3.15.0"
@@ -7216,7 +7205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.2.0":
   version: 4.3.0
   resolution: "js-yaml@npm:4.3.0"
   dependencies:


### PR DESCRIPTION
Fixes the last remaining Dependabot alert (#120) — `js-yaml` **Quadratic-complexity DoS in merge key handling** (GHSA-h67p-54hq-rp68 / CVE-2026-53550, Moderate).

`lerna@9.0.7` depends on `js-yaml@npm:4.1.1` as an **exact** version (not a `^`range), so the round-2 `js-yaml@^4.1.0` resolution didn't match it and that vulnerable copy survived. This adds an exact-descriptor resolution `"js-yaml@npm:4.1.1": "npm:^4.2.0"` moving it to 4.3.0.

After this, all `js-yaml` copies are safe (3.15.0, 4.3.0). Dev-only transitive dep, not in the published runtime bundle.

**Verification:** index / build / lint / docs OK; **179/179** tests green (Node 24); **0** vulnerable js-yaml versions remain in `yarn.lock`.