### PR TITLE
fix(types): dual-package type resolution (attw FalseESM + node16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,14 +58,12 @@ jobs:
       - name: publint (@semaver/reflector)
         run: yarn dlx publint@latest run ./packages/reflector
 
-      # attw surfaces a known pre-existing dual-package types issue (FalseESM on the
-      # single .d.ts used for both import & require). Report-only until the exports/types
-      # split is fixed and republished — see the maintainer notes. Does not fail CI yet.
+      # Package-correctness gate: attw must resolve types cleanly in all module modes
+      # (node10, node16-cjs, node16-esm, bundler). Blocking — the dual .d.ts/.d.cts split
+      # keeps this green; a regression here should fail CI.
       - name: attw — are-the-types-wrong (@semaver/core)
-        continue-on-error: true
         run: yarn dlx @arethetypeswrong/cli@latest --pack ./packages/core
       - name: attw — are-the-types-wrong (@semaver/reflector)
-        continue-on-error: true
         run: yarn dlx @arethetypeswrong/cli@latest --pack ./packages/reflector
 
       # Coverage upload is opt-in: only runs once CODECOV_TOKEN is configured.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,9 +20,14 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/library.esm.mjs",
-      "require": "./lib/library.cjs.cjs",
+      "import": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/library.esm.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.cts",
+        "default": "./lib/library.cjs.cjs"
+      },
       "default": "./lib/library.esm.mjs"
     },
     "./package.json": "./package.json"

--- a/packages/reflector/package.json
+++ b/packages/reflector/package.json
@@ -20,9 +20,14 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/library.esm.mjs",
-      "require": "./lib/library.cjs.cjs",
+      "import": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/library.esm.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.cts",
+        "default": "./lib/library.cjs.cjs"
+      },
       "default": "./lib/library.esm.mjs"
     },
     "./package.json": "./package.json"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,46 @@ import terser from "@rollup/plugin-terser";
 const PACKAGE_NAME = process.cwd();
 const pkg = JSON.parse(fs.readFileSync(path.join(PACKAGE_NAME, 'package.json'), 'utf-8'));
 
+// Fix TypeScript declaration files for Node16/NodeNext resolution and dual ESM/CJS packages.
+// tsconfig uses "moduleResolution": "Bundler", so emitted .d.ts re-exports carry NO file
+// extensions — which fails under node16 (both ESM and CJS) with an InternalResolutionError,
+// and a single .d.ts served for the CJS `require` path is flagged FalseESM ("masquerading as
+// ESM"). This plugin runs after declarations are emitted and:
+//   1. rewrites relative re-exports/imports in every .d.ts to carry a ".js" extension (ESM);
+//   2. writes a parallel tree of .d.cts files whose relative specifiers carry ".cjs".
+// package.json then points the `import` condition at .d.ts and `require` at .d.cts.
+// Verified green in all four attw modes (node10, node16-cjs, node16-esm, bundler).
+function fixDeclarationsForDualPackage(libDir) {
+    const addExt = (code, ext) =>
+        code.replace(
+            /(from\s+"|import\("|export\s+\*\s+from\s+")(\.\.?\/[^"]*?)"/g,
+            (m, head, spec) => (/\.(js|cjs|mjs|json)$/.test(spec) ? m : `${head}${spec}.${ext}"`)
+        );
+    const walk = (dir, out = []) => {
+        for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) walk(full, out);
+            else if (entry.name.endsWith(".d.ts")) out.push(full);
+        }
+        return out;
+    };
+    return {
+        name: "fix-declarations-for-dual-package",
+        writeBundle() {
+            const abs = path.join(PACKAGE_NAME, libDir);
+            if (!fs.existsSync(abs)) return;
+            for (const dtsPath of walk(abs)) {
+                // 1. ESM declaration: relative specifiers -> ".js"
+                const esm = addExt(fs.readFileSync(dtsPath, "utf-8"), "js");
+                fs.writeFileSync(dtsPath, esm);
+                // 2. CJS declaration sibling: relative specifiers -> ".cjs"
+                const ctsPath = dtsPath.replace(/\.d\.ts$/, ".d.cts");
+                fs.writeFileSync(ctsPath, addExt(esm.replace(/\.js"/g, '.cjs"'), "cjs"));
+            }
+        },
+    };
+}
+
 const commonjsOptions = {
     ignoreGlobal: true,
     include: /node_modules/,
@@ -97,6 +137,7 @@ export default {
         typescript(typescriptOptions),
         excludeDependenciesFromBundle({peerDependencies: true}),
         babel(babelOptions),
-        commonjs(commonjsOptions)
+        commonjs(commonjsOptions),
+        fixDeclarationsForDualPackage('lib')
     ]
 }


### PR DESCRIPTION
## Problem

`@arethetypeswrong/cli` (added to CI in #42) flagged both packages as broken for a subset of consumers:

- **FalseESM ("Masquerading as ESM")** — a single `lib/index.d.ts` was served for **both** the `import` (ESM) and `require` (CJS) `exports` conditions. For a `require`/CJS consumer, TypeScript then applied an ESM type declaration over CommonJS JavaScript.
- **InternalResolutionError (node16/nodenext)** — the tsconfig uses `"moduleResolution": "Bundler"`, so emitted `.d.ts` re-exports have **no file extensions** (`export * from "./com/..."`). Under `node16`/`nodenext` resolution that fails in **both** ESM and CJS modes.

Net effect: consumers on `moduleResolution: node16/nodenext` (especially CJS `require` in TypeScript) could get mis-resolved or failing types. Runtime was unaffected — this was a **types-only** dual-package defect. Baseline attw: 🟢 node10 / 🟢 bundler, but 👺+🥴 on both node16 rows.

## Fix

- **`rollup.config.js`** — new `fixDeclarationsForDualPackage` plugin runs after declarations are emitted and:
  1. rewrites relative re-exports/imports in every `.d.ts` to carry a `.js` extension (valid ESM);
  2. writes a parallel tree of `.d.cts` files whose relative specifiers carry `.cjs`.
- **`packages/{core,reflector}/package.json`** — split the `exports` map into
  `import → { types: ./lib/index.d.ts }` and `require → { types: ./lib/index.d.cts }`.

No source or runtime-bundle changes; declaration files only.

## Verification

- **attw: 🟢 in all four modes** (node10, node16-cjs, node16-esm, bundler) for **both** `@semaver/core` and `@semaver/reflector`.
- `build` + **179/179** tests pass; lint clean (Node 24).
- `.d.cts` files are included in the `npm pack` tarball.
- **Verdaccio end-to-end:** published both packages to a local registry and installed them into external **ESM** and **CJS** scratch projects — `tsc --noEmit` with `moduleResolution: nodenext` exits **0** in both.

## Note

The affected types are already published in **2.1.0**; this fix ships in **2.1.1**.