### PR TITLE
chore(release): bump packages to 2.1.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "yarn",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "command": {
     "publish": {
       "graphType": "all"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "split-ts-core-stack",
   "private": true,
   "type": "module",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "homepage": "https://github.com/semaver/core-stack",
   "bugs": "https://github.com/semaver/core-stack/issues",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@semaver/core",
   "type": "module",
   "rawName": "core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Core interface/types and helper methods for object manipulation and reflection",
   "homepage": "https://github.com/semaver/core-stack",
   "bugs": "https://github.com/semaver/core-stack/issues",

--- a/packages/reflector/package.json
+++ b/packages/reflector/package.json
@@ -2,7 +2,7 @@
   "name": "@semaver/reflector",
   "type": "module",
   "rawName": "reflector",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Reflection framework for TypeScript and JavaScript, with decorator inheritance support and no reflect-metadata dependency.",
   "homepage": "https://github.com/semaver/core-stack",
   "bugs": "https://github.com/semaver/core-stack/issues",
@@ -72,10 +72,10 @@
     "file": "yarn pack --pack-destination packs"
   },
   "devDependencies": {
-    "@semaver/core": "^2.1.0"
+    "@semaver/core": "^2.1.1"
   },
   "peerDependencies": {
-    "@semaver/core": "^2.1.0"
+    "@semaver/core": "^2.1.1"
   },
   "engines": {
     "node": ">=22.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3359,7 +3359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@semaver/core@npm:^2.1.0, @semaver/core@workspace:packages/core":
+"@semaver/core@npm:^2.1.1, @semaver/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@semaver/core@workspace:packages/core"
   languageName: unknown
@@ -3369,9 +3369,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@semaver/reflector@workspace:packages/reflector"
   dependencies:
-    "@semaver/core": "npm:^2.1.0"
+    "@semaver/core": "npm:^2.1.1"
   peerDependencies:
-    "@semaver/core": ^2.1.0
+    "@semaver/core": ^2.1.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Fixed-mode version bump to **2.1.1**, shipping the dual-package types fix (#49).

- root, `lerna.json`, `@semaver/core`, `@semaver/reflector` → 2.1.1
- reflector's internal `@semaver/core` peer/dev refs → `^2.1.1`

Verified: build + **179/179** tests + attw 🟢 (all four modes) on 2.1.1.