### PR TITLE
ci(dependabot): pin typescript to 6.x (ignore 7.0+)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
       # Runtime deps grouped separately so production changes stay visible.
       production-dependencies:
         dependency-type: production
+    ignore:
+      # TypeScript 7.0 (native Go compiler) breaks the rollup build:
+      # "@rollup/plugin-typescript@12" hits `TypeError: Cannot read properties of
+      # undefined (reading 'ES2015')" — the plugin isn't compatible with the TS7
+      # internal ScriptTarget API. Stay on 6.x until the toolchain supports TS7.
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
     labels:
       - dependencies
 


### PR DESCRIPTION
Pin TypeScript to the 6.x line for Dependabot.

**Why:** TypeScript 7.0 (the native Go compiler) breaks the rollup build —
`@rollup/plugin-typescript@12` throws `TypeError: Cannot read properties of undefined (reading 'ES2015')`
because it isn't compatible with the TS7 internal `ScriptTarget` API. Reproduced locally: `build` fails on 7.0.2.

Adds an `ignore` for `typescript >=7.0.0` so Dependabot stops proposing it (this is what made the grouped
dev-deps PR #48 fail CI). We stay on the pinned `6.0.3` until the toolchain supports TS7.