### PR TITLE
fix(security): pin transitive axios to 1.18.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "brace-expansion@npm:^1.1.7": "npm:^1.1.13",
     "js-yaml@npm:^3.13.1": "npm:^3.15.0",
     "js-yaml@npm:4.1.1": "npm:^4.2.0",
-    "ip-address@npm:^9.0.5": "npm:^10.1.1"
+    "ip-address@npm:^9.0.5": "npm:^10.1.1",
+    "axios@npm:1.16.0": "npm:^1.18.0"
   },
   "devDependencies": {
     "@babel/core": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4119,6 +4119,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agent-base@npm:6":
+  version: 6.0.2
+  resolution: "agent-base@npm:6.0.2"
+  dependencies:
+    debug: "npm:4"
+  checksum: 10c0/dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
+  languageName: node
+  linkType: hard
+
 "agent-base@npm:^7.0.2, agent-base@npm:^7.1.0, agent-base@npm:^7.1.1":
   version: 7.1.1
   resolution: "agent-base@npm:7.1.1"
@@ -4266,14 +4275,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.16.0":
-  version: 1.16.0
-  resolution: "axios@npm:1.16.0"
+"axios@npm:^1.18.0":
+  version: 1.18.1
+  resolution: "axios@npm:1.18.1"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/1c91a5221b77b76072026b4cc95ecdf38f7c3e33e63423abec09a85e6e9a12279637dcc9ac2ba1fc333e0c447fb3b0f46d7965acb5d7cea02d188e9c6d425c0b
+  checksum: 10c0/9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
   languageName: node
   linkType: hard
 
@@ -6287,6 +6297,16 @@ __metadata:
     agent-base: "npm:^7.1.0"
     debug: "npm:^4.3.4"
   checksum: 10c0/4207b06a4580fb85dd6dff521f0abf6db517489e70863dca1a0291daa7f2d3d2d6015a57bd702af068ea5cf9f1f6ff72314f5f5b4228d299c0904135d2aef921
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "https-proxy-agent@npm:5.0.1"
+  dependencies:
+    agent-base: "npm:6"
+    debug: "npm:4"
+  checksum: 10c0/6dd639f03434003577c62b27cafdb864784ef19b2de430d8ae2a1d45e31c4fd60719e5637b44db1a88a046934307da7089e03d6089ec3ddacc1189d8de8897d1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pins the transitive **axios** dependency onto a patched version via root `resolutions`.

`nx@22.7.6` pins `axios@npm:1.16.0` **exactly**, which is affected by 5 Dependabot advisories (1 High + 4 Medium): proxy/interceptor leak (GHSA-gcfj-64vw-6mp9), form-serializer maxDepth bypass, HTTP/2 maxBodyLength bypass, NO_PROXY 0.0.0.0 bypass, Basic-auth prototype pollution. All fixed in **1.18.0**.

Adds `"axios@npm:1.16.0": "npm:^1.18.0"` → resolves to **1.18.1**. Dev-only transitive dep (via `nx`), not in the published runtime bundle.

**Verification (full local run):** build · 179/179 tests · lint · docs · publint (both) · attw 4/4 (both) — all green; `yarn.lock` has 0 vulnerable axios.