### PR TITLE
fix(security): pin brace-expansion 5.x to 5.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "minimatch@npm:^9.0.4": "npm:^9.0.7",
     "tar@npm:7.5.11": "npm:^7.5.16",
     "brace-expansion@npm:^1.1.7": "npm:^1.1.13",
+    "brace-expansion@npm:5.0.6": "npm:^5.0.7",
+    "brace-expansion@npm:^5.0.5": "npm:^5.0.7",
     "js-yaml@npm:^3.13.1": "npm:^3.15.0",
     "js-yaml@npm:4.1.1": "npm:^4.2.0",
     "ip-address@npm:^9.0.5": "npm:^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4443,15 +4443,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.6":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
-  languageName: node
-  linkType: hard
-
 "brace-expansion@npm:^1.1.13":
   version: 1.1.16
   resolution: "brace-expansion@npm:1.1.16"
@@ -4471,7 +4462,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
+"brace-expansion@npm:^5.0.7":
   version: 5.0.7
   resolution: "brace-expansion@npm:5.0.7"
   dependencies:


### PR DESCRIPTION
Fixes the new **brace-expansion** advisory **GHSA-3jxr-9vmj-r5cp** (High — DoS via exponential-time expansion of consecutive non-expanding `{}` groups), affecting `>=3.0.0 <5.0.7`.

`nx@22.7.6` pins `brace-expansion@npm:5.0.6` exactly (the 5.x line was safe in the round-2 pins, but this CVE is newer). Pin the 5.x line to `^5.0.7` via `resolutions`. Dev-only transitive dep (via `nx`), not in the published runtime bundle.

**Verification:** build + **179/179** tests green; `yarn.lock` brace-expansion now only 1.1.16 / 2.1.2 / 5.0.7 — 0 in the vulnerable range.