### PR TITLE
ci(commitlint): disable body/footer max-line-length

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,3 +1,9 @@
 export default {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Dependabot and changelog commit bodies embed long compare/release URLs;
+    // the header (type/scope/subject) is what we actually enforce.
+    'body-max-line-length': [0],
+    'footer-max-line-length': [0],
+  },
 };


### PR DESCRIPTION
Fixes the false-failing **Commit messages** CI job on Dependabot PRs (#58–62).

Dependabot commit bodies embed long compare/release URLs (e.g. 145 chars) that trip `body-max-line-length=100`. The header (type/scope/subject) is what we enforce; body/footer length rules are disabled. Verified: the failing #58 message now passes, and a header without a type still fails.