### PR TITLE
ci(sonar): add SonarQube Cloud analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
   verify:
     name: Build, lint, test & package checks
     runs-on: ubuntu-latest
+    env:
+      # Exposed at job level so the step-level `if: env.SONAR_TOKEN != ''` guard works.
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       # Runtime hardening (audit mode first; switch to block + allowlist once egress is known).
       - name: Harden runner
@@ -84,6 +87,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           fail_ci_if_error: false
+
+      # SonarQube Cloud analysis (quality + coverage). Opt-in: only runs once SONAR_TOKEN
+      # is configured. Reads coverage/lcov.info produced by the test step above.
+      - name: SonarQube Cloud scan
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
 
   commitlint:
     name: Commit messages (Conventional Commits)

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -7,7 +7,7 @@ export const base = {
 		"js",
 	],
 	collectCoverage: true,
-	coverageReporters: ["html", "text"],
+	coverageReporters: ["html", "text", "lcov"],
 	verbose: true,
 	maxWorkers: "0%",
 };

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.organization=semaver
+sonar.projectKey=semaver_core-stack
+
+# Monorepo sources & tests
+sonar.sources=packages/core/src,packages/reflector/src
+sonar.tests=packages/core/tests,packages/reflector/tests
+
+# Coverage (root jest writes an aggregated lcov via `yarn test:all`)
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Exclusions: built output, generated docs, barrels, type declarations
+sonar.exclusions=**/lib/**,docs/**,**/index.ts,**/*.d.ts,**/*.d.cts
+sonar.coverage.exclusions=**/tests/**,**/*.spec.ts,**/index.ts


### PR DESCRIPTION
Wires up SonarQube Cloud analysis (last of the external services from `.claude/TOOLING.md`).

- **jest.config.base.js**: add `lcov` to `coverageReporters` → `yarn test:all` now writes `coverage/lcov.info` (needed by Sonar; also feeds Codecov).
- **sonar-project.properties**: `organization=semaver`, `projectKey=semaver_core-stack`, monorepo sources/tests, lcov coverage path, exclusions (lib/docs/barrels/decls).
- **ci.yml**: `SonarSource/sonarqube-scan-action` step (pinned SHA), opt-in via `SONAR_TOKEN` (job-level env guard), runs after tests emit lcov.

Requires the `SONAR_TOKEN` repo secret (already added) and **Automatic Analysis disabled** in SonarCloud (CI-based analysis instead). Verified locally: lcov is produced after build+test; YAML valid; build/test unaffected.