### PR TITLE
refactor: apply safe SonarCloud fixes in src

### DIFF
--- a/packages/core/src/com/split/core/extentions/InterfaceSymbol.ts
+++ b/packages/core/src/com/split/core/extentions/InterfaceSymbol.ts
@@ -12,7 +12,7 @@ export class InterfaceSymbol<T> implements IInterface<T> {
      * @private
      * @property pool of all interface symbols
      */
-    private static pool: Map<symbol, InterfaceSymbol<unknown>> = new Map<symbol, InterfaceSymbol<unknown>>();
+    private static readonly pool: Map<symbol, InterfaceSymbol<unknown>> = new Map<symbol, InterfaceSymbol<unknown>>();
     /**
      * @public
      * @readonly

--- a/packages/reflector/src/com/split/metatable/MetadataFactory.ts
+++ b/packages/reflector/src/com/split/metatable/MetadataFactory.ts
@@ -139,33 +139,33 @@ export function getConstructorMetadata<T extends object>(target: T): IMemberMeta
  */
 export function getMetadata<T extends object>(target: T, classMemberName?: string, propertyDescriptorOrIndex?: TypedPropertyDescriptor<T> | number): Throwable<IMemberMetadata<T>> {
     let propertyDescriptor: Empty<TypedPropertyDescriptor<T>>;
-    let index: number = NaN;
+    let index: number = Number.NaN;
 
     if (propertyDescriptorOrIndex !== undefined) {
-        if (isNaN(+propertyDescriptorOrIndex)) {
+        if (Number.isNaN(+propertyDescriptorOrIndex)) {
             propertyDescriptor = propertyDescriptorOrIndex as Empty<TypedPropertyDescriptor<T>>;
         } else {
             index = +propertyDescriptorOrIndex;
         }
     }
 
-    if (classMemberName && isNaN(index) && propertyDescriptor?.value instanceof Function) {
+    if (classMemberName && Number.isNaN(index) && propertyDescriptor?.value instanceof Function) {
         return getMethodMetadata(target, classMemberName);
     }
 
-    if (classMemberName && isNaN(index) && (propertyDescriptor?.get || propertyDescriptor?.set)) {
+    if (classMemberName && Number.isNaN(index) && (propertyDescriptor?.get || propertyDescriptor?.set)) {
         return getAccessorMetadata(target, classMemberName);
     }
 
-    if (classMemberName && isNaN(index) && !propertyDescriptor) {
+    if (classMemberName && Number.isNaN(index) && !propertyDescriptor) {
         return getPropertyMetadata(target, classMemberName);
     }
 
-    if (!isNaN(index) && !propertyDescriptor) {
+    if (!Number.isNaN(index) && !propertyDescriptor) {
         return getParameterMetadata(target, classMemberName, index);
     }
 
-    if (!classMemberName && isNaN(index) && !propertyDescriptor) {
+    if (!classMemberName && Number.isNaN(index) && !propertyDescriptor) {
         return getConstructorMetadata(target);
     }
 

--- a/packages/reflector/src/com/split/metatable/MetadataTableProvider.ts
+++ b/packages/reflector/src/com/split/metatable/MetadataTableProvider.ts
@@ -124,7 +124,7 @@ export class MetadataTableProvider<T extends object = object> {
      * @returns own metadata table of provided class
      */
     private static getOrCreateClassMetadataTable<T>(target: IMetadataClass<T>): IMetadataTableRef {
-        if (Reflect.ownKeys(target).find((value) => value === MetadataClassNames.METADATA)) {
+        if (Reflect.ownKeys(target).includes(MetadataClassNames.METADATA)) {
             return target.__metadata__;
         } else {
             const metadataTable: IMetadataTableRef = createMetadataTable();
@@ -747,7 +747,7 @@ export class MetadataTableProvider<T extends object = object> {
     private deleteMemberMetadata(decorator: IMetatableDecorator, membersMetadataTable: Map<string, IMemberMetadataTableRef>): boolean {
         let isDeleted: boolean = false;
         const memberMetadataTable: IMemberMetadataTableRef = getMapElementOrDefault(membersMetadataTable, decorator.__metadata__.name, createMemberMetadataTable());
-        const index: number = memberMetadataTable._decorators.findIndex((memberDecorator) => decorator === memberDecorator);
+        const index: number = memberMetadataTable._decorators.indexOf(decorator);
         if (index !== -1) {
             memberMetadataTable._decorators.splice(index, 1);
             isDeleted = true;
@@ -779,7 +779,7 @@ export class MetadataTableProvider<T extends object = object> {
                 parameters[i] = [];
             }
             if (i === decorator.__metadata__.parameterIndex) {
-                const index: number = parameters[i].findIndex((memberDecorator) => decorator === memberDecorator);
+                const index: number = parameters[i].indexOf(decorator);
                 if (index !== -1) {
                     parameters[i].splice(index, 1);
                     isDeleted = true;

--- a/packages/reflector/src/com/split/reflector/members/Constructor.ts
+++ b/packages/reflector/src/com/split/reflector/members/Constructor.ts
@@ -14,7 +14,7 @@ import {Parameter} from "./Parameter";
  */
 export class Constructor<T extends object = object> extends ExecutableMember<T> {
 
-    public static defaultName: string = "ctor";
+    public static readonly defaultName: string = "ctor";
 
     /**
      * @public

--- a/packages/reflector/src/com/split/reflector/query/conditions/decorators/ByDecoratorClass.ts
+++ b/packages/reflector/src/com/split/reflector/query/conditions/decorators/ByDecoratorClass.ts
@@ -18,7 +18,7 @@ export class ByDecoratorClass<T extends object = object> implements IQueryCondit
      * @property _cache - cache that contains instance of current query/filter condition
      * to prevent creation of instance every time this condition required (reusing of instance)
      */
-    private static _cache: ByDecoratorClass = new ByDecoratorClass<object>();
+    private static readonly _cache: ByDecoratorClass = new ByDecoratorClass<object>();
     /**
      * @private
      * @property _decoratorClasses - collection of decorator classes
@@ -78,7 +78,7 @@ export class ByDecoratorClass<T extends object = object> implements IQueryCondit
                         decorators.push(...parameter.getDecorators());
                     });
                 }
-                return !!decorators.find((decorator) => this._decoratorClasses.some((decoratorClass) => decoratorClass === classOfObject(decorator)));
+                return decorators.some((decorator) => this._decoratorClasses.includes(classOfObject(decorator)));
             });
     }
 }

--- a/packages/reflector/src/com/split/reflector/query/conditions/decorators/ByMemberDecoratorClass.ts
+++ b/packages/reflector/src/com/split/reflector/query/conditions/decorators/ByMemberDecoratorClass.ts
@@ -15,7 +15,7 @@ export class ByMemberDecoratorClass<T extends object = object> implements IQuery
      * @property _cache - cache that contains instance of current query/filter condition
      * to prevent creation of instance every time this condition required (reusing of instance)
      */
-    private static _cache: ByMemberDecoratorClass = new ByMemberDecoratorClass<object>();
+    private static readonly _cache: ByMemberDecoratorClass = new ByMemberDecoratorClass<object>();
     /**
      * @private
      * @property _decoratorClasses - collection of decorator classes used in query/filter condition
@@ -63,7 +63,7 @@ export class ByMemberDecoratorClass<T extends object = object> implements IQuery
                 return member.getDecorators()
                     .some((decorator) => {
                         return this._decoratorClasses
-                            .some((metadataClass) => metadataClass === classOfObject(decorator));
+                            .includes(classOfObject(decorator));
                     });
             });
     }

--- a/packages/reflector/src/com/split/reflector/query/conditions/decorators/ByParameterDecoratorClass.ts
+++ b/packages/reflector/src/com/split/reflector/query/conditions/decorators/ByParameterDecoratorClass.ts
@@ -17,7 +17,7 @@ export class ByParameterDecoratorClass<T extends object = object> implements IQu
      * @property _cache - cache that contains instance of current query/filter condition
      * to prevent creation of instance every time this condition required (reusing of instance)
      */
-    private static _cache: ByParameterDecoratorClass = new ByParameterDecoratorClass<object>();
+    private static readonly _cache: ByParameterDecoratorClass = new ByParameterDecoratorClass<object>();
     /**
      * @private
      * @property _decoratorClasses - collection of decorator classes used in query/filter condition
@@ -69,7 +69,7 @@ export class ByParameterDecoratorClass<T extends object = object> implements IQu
                     return member
                         .getParameterDecorators()
                         .reduce((result, decorators) => result.concat(...decorators), [])
-                        .some((decorator) => !!this._decoratorClasses.find((decoratorClass) => decoratorClass === classOfObject(decorator)));
+                        .some((decorator) => this._decoratorClasses.includes(classOfObject(decorator)));
 
                 } else {
                     return false;

--- a/packages/reflector/src/com/split/reflector/query/conditions/members/ByMemberName.ts
+++ b/packages/reflector/src/com/split/reflector/query/conditions/members/ByMemberName.ts
@@ -12,7 +12,7 @@ export class ByMemberName<T extends object = object> implements IQueryCondition<
      * @property _cache - cache that contains instance of current query/filter condition
      * to prevent creation of instance every time this condition required (reusing of instance)
      */
-    private static _cache: ByMemberName = new ByMemberName<object>();
+    private static readonly _cache: ByMemberName = new ByMemberName<object>();
     /**
      * @private
      * @property _memberNames - collection of class members names used in query/filter condition
@@ -57,8 +57,7 @@ export class ByMemberName<T extends object = object> implements IQueryCondition<
     public filter(queryInfo: QueryInfo<T>): void {
         queryInfo
             .filterMembers((member) => {
-                return this._memberNames.some((memberName) =>
-                    memberName === member.getName());
+                return this._memberNames.includes(member.getName());
             });
     }
 

--- a/packages/reflector/src/com/split/reflector/query/conditions/members/ByMemberType.ts
+++ b/packages/reflector/src/com/split/reflector/query/conditions/members/ByMemberType.ts
@@ -16,7 +16,7 @@ export class ByMemberType<T extends object = object> implements IQueryCondition<
      * @property _cache - cache that contains instance of current query/filter condition
      * to prevent creation of instance every time this condition required (reusing of instance)
      */
-    private static _cache: ByMemberType = new ByMemberType<object>();
+    private static readonly _cache: ByMemberType = new ByMemberType<object>();
     /**
      * @private
      * @property _memberTypes - collection of class members types used in query/filter condition

--- a/packages/reflector/src/com/split/reflector/query/conditions/members/ByStaticMember.ts
+++ b/packages/reflector/src/com/split/reflector/query/conditions/members/ByStaticMember.ts
@@ -14,7 +14,7 @@ export class ByStaticMember<T extends object = object> implements IQueryConditio
      * @property _cache - cache that contains instance of current query/filter condition
      * to prevent creation of instance every time this condition required (reusing of instance)
      */
-    private static _cache: ByStaticMember = new ByStaticMember<object>();
+    private static readonly _cache: ByStaticMember = new ByStaticMember<object>();
     /**
      * @private
      * @property _isStatic - statics flag


### PR DESCRIPTION
Applies the **safe wave** of SonarCloud code-smell fixes in `src` — mechanical, behavior-preserving. 22 issues addressed.

| Rule | Fix | Count |
|---|---|---|
| S7773 | `NaN`→`Number.NaN`, `isNaN()`→`Number.isNaN()` (args already numeric) | 7 |
| S2933 | mark non-reassigned static fields `readonly` (`_cache`×6, `InterfaceSymbol.pool`) | 7 |
| S1444 | `Constructor.defaultName` → `static readonly` | 1 |
| S7765/S7754 | `.some(x=>x===v)` / `.find(...)`-as-boolean → `.includes(v)` / `.some(...)` | 5 |
| S7753 | `.findIndex(x=>x===v)` → `.indexOf(v)` | 2 |

**Not touched (needs review, follow-up):** S6676 `.apply()` in members (may be intentional for reflection), S3735 `void` in Decorator, S3776 cognitive complexity ×2, S7732 `instanceof`, S1135 TODOs.

**Note on the skipped S2933s:** the 5 mutable fields (`_decoratorClasses` etc.) are reassigned in setters, so `readonly` would break them — only the truly-immutable static refs were marked.

**Verified:** build + lint + **179/179** tests green (Node 24). Sonar will re-scan on this PR.