### PR TITLE
ci(metrics): publish metrics as artifact instead of committing to main

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: metrics
@@ -44,15 +44,12 @@ jobs:
           echo "$line" >> .metrics/history.csv
           tail -5 .metrics/history.csv
 
-      - name: Commit metrics
-        run: |
-          set -euo pipefail
-          if [[ -n "$(git status --porcelain .metrics)" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add .metrics
-            git commit -m "chore(metrics): weekly download & dependents snapshot"
-            git push
-          else
-            echo "No metrics change."
-          fi
+      # `main` is a protected branch (no direct pushes), so we publish the metrics
+      # as a build artifact instead of committing them. Each run keeps its own
+      # snapshot; download from the run's Artifacts section.
+      - name: Upload metrics artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: metrics
+          path: .metrics/history.csv
+          retention-days: 90


### PR DESCRIPTION
Fixes the failing **Metrics** workflow. It tried to `git push` `.metrics/history.csv` to `main`, which is a protected branch → `GH006: Protected branch update failed (changes must be made through a pull request)`.

Instead of committing, the workflow now **publishes the CSV as a build artifact** (`actions/upload-artifact`, 90-day retention). No push, no branch-protection conflict. `permissions` downgraded to `contents: read`.

Trade-off: metrics history lives per-run in the Artifacts section rather than accumulating in the repo — appropriate for a lightweight monitoring signal and keeps `main` clean.