### PR TITLE
fix(security): pin ip-address and undici to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "js-yaml@npm:^3.13.1": "npm:^3.15.0",
     "js-yaml@npm:4.1.1": "npm:^4.2.0",
     "ip-address@npm:^9.0.5": "npm:^10.1.1",
+    "ip-address@npm:^10.1.1": "npm:^10.2.2",
+    "undici@npm:^8.4.1": "npm:^8.9.0",
     "axios@npm:1.16.0": "npm:^1.18.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7534,9 +7534,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 10c0/d7b0bd2624fd861afbae6e49036a9b56f9506eaff7ff38592b7b4492dd5c272b53f5356dc8cc019e318acf29a96c90a3d1af1df761960267d23efa96858270fa
   languageName: node
   linkType: hard
 
@@ -11752,10 +11752,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^8.4.1":
-  version: 8.7.0
-  resolution: "undici@npm:8.7.0"
-  checksum: 10c0/b7e5ecb4de82fa4f905011a77544fe7ba4da06f27167ff99313a7ae2869f3cb233d676dcd085533bc69f36989bc40871f5ae6ea6e4c9b91db92616b9e91b579d
+"undici@npm:^8.9.0":
+  version: 8.10.0
+  resolution: "undici@npm:8.10.0"
+  checksum: 10c0/37ae2b1db8f65c3a003504e2040e96887b99f9db16ba07dcf49c37ed8b7f8c72f4452f2d46f52f7c9e49518fe8325e3b5e7e02ac3a2424886bd67d4b62a0ecab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes 7 Dependabot alerts via `resolutions` (all dev-only transitive deps, not in the published runtime bundle).

**ip-address** (2× Medium — XSS/path traversal in Address6 HTML-emitting methods)

| GHSA | Range | Fix |
|---|---|---|
| GHSA-4xrf-jv44-h6hh | >= 10.1.1, <= 10.2.1 | 10.2.2 |
| GHSA-22jq-vg5j-6vgg | >= 10.1.1, <= 10.2.0 | 10.2.1 |

Pinned to `^10.2.2`, resolved to **10.4.0**. Pulled via `socks` → `@npmcli/arborist` (dev-only).

**undici** (4× Medium + 1× High — request smuggling / SSRF / header injection on the 8.x line)

All five CVEs affect `>= 8.0.0, < 8.9.0`. Pinned to `^8.9.0`, resolved to **8.10.0**. Pulled via `node-gyp@13` (dev-only). The 6.x line (6.27.0) is unaffected and untouched.

**Supersedes Dependabot PR #76** (ip-address 10.2.0→10.4.0 — our resolution already achieves this). PR #75 (undici 6.x bump) is a non-security routine update; handled separately.

**Verified:** build + **179/179** tests green; 0 vulnerable versions in `yarn.lock`.