### PR TITLE
chore: add .serena/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .claude/
 .idea/
+.serena/
 *.iml
 *.log
 


### PR DESCRIPTION
## What

Add `.serena/` to `.gitignore`.

## Why

[Serena](https://github.com/oraios/serena) is an LSP-based code-navigation MCP tool. When active in a session it creates a local `.serena/` directory at the repo root containing its cache, memories, and project config (`project.yml`, `project.local.yml`). This is a local developer-tool artifact — not part of the project — so it should not be tracked, consistent with the already-ignored `.claude/` and `.idea/` directories.

## Changes

- `.gitignore`: add `.serena/` alongside the other tool directories.

No source, build, or runtime impact. Dev-only housekeeping.
